### PR TITLE
CCM-6603 fixing relative paths

### DIFF
--- a/infrastructure/terraform/components/cdn/module_lambda_remove_origin_request_path.tf
+++ b/infrastructure/terraform/components/cdn/module_lambda_remove_origin_request_path.tf
@@ -1,5 +1,6 @@
 module "lambda_remove_origin_request_path" {
-  source = "git::https://github.com/NHSDigital/nhs-notify-shared-modules.git//infrastructure/modules/lambda?ref=v1.0.0"
+  source = "git::https://github.com/NHSDigital/nhs-notify-shared-modules.git//infrastructure/modules/lambda?ref=v1.0.1"
+
   providers = {
     aws = aws.us-east-1
   }

--- a/infrastructure/terraform/components/cdn/module_lambda_rewrite_origin_branch_requests.tf
+++ b/infrastructure/terraform/components/cdn/module_lambda_rewrite_origin_branch_requests.tf
@@ -1,5 +1,6 @@
 module "lambda_rewrite_origin_branch_requests" {
-  source = "git::https://github.com/NHSDigital/nhs-notify-shared-modules.git//infrastructure/modules/lambda?ref=v1.0.0"
+  source = "git::https://github.com/NHSDigital/nhs-notify-shared-modules.git//infrastructure/modules/lambda?ref=v1.0.1"
+
   providers = {
     aws = aws.us-east-1
   }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Updates the version pin for the lambda module, 1.0.0 used path.module, 1.0.1 now uses path.root for sourcing the lambda files.
The problem with moving the lambda module to its own repo is it now gets pulled in to .terraform/$path_to_folder rather than ../modules/lambda relative to the component. using path.root fixes this and brings sourcing the files back to being relative to to the component not the module

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
