### PR TITLE
CCM-7908 adding mechanism for TFVAR based secret

### DIFF
--- a/infrastructure/terraform/components/cdn/cloudfront_distribution_cdn.tf
+++ b/infrastructure/terraform/components/cdn/cloudfront_distribution_cdn.tf
@@ -104,7 +104,7 @@ resource "aws_cloudfront_distribution" "main" {
       }
 
       dynamic "custom_header" {
-        for_each = var.amplify_basic_auth_secret != "unset" ? [1] : []
+        for_each = var.AMPLIFY_BASIC_AUTH_SECRET != "unset" ? [1] : []
 
         content {
           name  = "Authorization"

--- a/infrastructure/terraform/components/cdn/cloudfront_distribution_cdn.tf
+++ b/infrastructure/terraform/components/cdn/cloudfront_distribution_cdn.tf
@@ -104,11 +104,11 @@ resource "aws_cloudfront_distribution" "main" {
       }
 
       dynamic "custom_header" {
-        for_each = var.cdn_authorization_header_secret != "unset" ? [1] : []
+        for_each = var.amplify_basic_auth_secret != "unset" ? [1] : []
 
         content {
           name  = "Authorization"
-          value = aws_ssm_parameter.cdn_authorization_header_secret[0].value
+          value = aws_ssm_parameter.amplify_basic_auth_secret[0].value
         }
       }
     }

--- a/infrastructure/terraform/components/cdn/cloudfront_distribution_cdn.tf
+++ b/infrastructure/terraform/components/cdn/cloudfront_distribution_cdn.tf
@@ -102,6 +102,15 @@ resource "aws_cloudfront_distribution" "main" {
         name  = "x-amplify-base-url"
         value = origin.value.root_dns_record
       }
+
+      dynamic "custom_header" {
+        for_each = var.cdn_authorization_header_secret != "unset" ? [1] : []
+
+        content {
+          name  = "Authorization"
+          value = aws_ssm_parameter.cdn_authorization_header_secret[0].value
+        }
+      }
     }
   }
 

--- a/infrastructure/terraform/components/cdn/ssm_parameter_amplify_password.tf
+++ b/infrastructure/terraform/components/cdn/ssm_parameter_amplify_password.tf
@@ -1,7 +1,9 @@
 resource "aws_ssm_parameter" "amplify_basic_auth_secret" {
-  count = var.amplify_basic_auth_secret != "unset" ? 1 : 0
+  count = var.AMPLIFY_BASIC_AUTH_SECRET != "unset" ? 1 : 0
 
-  name  = "/${local.csi}/amplify_basic_auth_secret"
+  name        = "/${local.csi}/amplify_basic_auth_secret"
+  description = "The Basic Auth password used for the amplify app. This parameter is sourced from Github Environment variables"
+
   type  = "String"
-  value = var.amplify_basic_auth_secret
+  value = var.AMPLIFY_BASIC_AUTH_SECRET
 }

--- a/infrastructure/terraform/components/cdn/ssm_parameter_amplify_password.tf
+++ b/infrastructure/terraform/components/cdn/ssm_parameter_amplify_password.tf
@@ -1,0 +1,7 @@
+resource "aws_ssm_parameter" "cdn_authorization_header_secret" {
+  count = var.cdn_authorization_header_secret != "unset" ? 1 : 0
+
+  name  = "/${local.csi}/cdn_authorization_header_secret"
+  type  = "String"
+  value = var.cdn_authorization_header_secret
+}

--- a/infrastructure/terraform/components/cdn/ssm_parameter_amplify_password.tf
+++ b/infrastructure/terraform/components/cdn/ssm_parameter_amplify_password.tf
@@ -1,7 +1,7 @@
-resource "aws_ssm_parameter" "cdn_authorization_header_secret" {
-  count = var.cdn_authorization_header_secret != "unset" ? 1 : 0
+resource "aws_ssm_parameter" "amplify_basic_auth_secret" {
+  count = var.amplify_basic_auth_secret != "unset" ? 1 : 0
 
-  name  = "/${local.csi}/cdn_authorization_header_secret"
+  name  = "/${local.csi}/amplify_basic_auth_secret"
   type  = "String"
-  value = var.cdn_authorization_header_secret
+  value = var.amplify_basic_auth_secret
 }

--- a/infrastructure/terraform/components/cdn/variables.tf
+++ b/infrastructure/terraform/components/cdn/variables.tf
@@ -99,6 +99,13 @@ variable "amplify_microservice_routes" {
 variable "cdn_sans" {
   type        = list(string)
   description = "Aliases to associate with CDN"
+  default     = []
+}
+
+variable "cdn_authorization_header_secret" {
+  type        = string
+  description = "Secret key/password to use for microservice headers - This is entended to be read from CI variables and not commited to any codebase"
+  default     = "unset"
 }
 
 variable "cms_origin" {

--- a/infrastructure/terraform/components/cdn/variables.tf
+++ b/infrastructure/terraform/components/cdn/variables.tf
@@ -102,7 +102,8 @@ variable "cdn_sans" {
   default     = []
 }
 
-variable "amplify_basic_auth_secret" {
+variable "AMPLIFY_BASIC_AUTH_SECRET" {
+  # Github only does uppercase env vars
   type        = string
   description = "Secret key/password to use for amplify microservice headers - This is entended to be read from CI variables and not commited to any codebase"
   default     = "unset"

--- a/infrastructure/terraform/components/cdn/variables.tf
+++ b/infrastructure/terraform/components/cdn/variables.tf
@@ -102,9 +102,9 @@ variable "cdn_sans" {
   default     = []
 }
 
-variable "cdn_authorization_header_secret" {
+variable "amplify_basic_auth_secret" {
   type        = string
-  description = "Secret key/password to use for microservice headers - This is entended to be read from CI variables and not commited to any codebase"
+  description = "Secret key/password to use for amplify microservice headers - This is entended to be read from CI variables and not commited to any codebase"
   default     = "unset"
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds a mechanism by which the authorization headers for the three microservices can be set consistently so that communication between auth, templates and the gateway can be centrally managed per

TF_VAR_amplify_basic_auth_secret is set on the internal repo already, merging this will cause access to be limited while the CDN, IAM-Webauth, and Web-Templates are deployed  and pick this up

<!-- Describe your changes in detail. -->

## Context
[TDA-2024-03](https://nhsd-confluence.digital.nhs.uk/pages/viewpage.action?spaceKey=RIS&title=TDA-2024-03)

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
