### PR TITLE
CCM-8579: Allow oversized body for create/edit letter

### DIFF
--- a/infrastructure/terraform/components/cdn/wafv2_web_acl.tf
+++ b/infrastructure/terraform/components/cdn/wafv2_web_acl.tf
@@ -119,17 +119,35 @@ resource "aws_wafv2_web_acl" "main" {
           }
         }
         statement {
-          not_statement {
+          or_statement {
             statement {
-              regex_match_statement {
-                field_to_match {
-                  uri_path {}
+              not_statement {
+                statement {
+                  regex_match_statement {
+                    field_to_match {
+                      uri_path {}
+                    }
+                    # only uri to allow >8kb body is /templates(~<dynamic environment>)/<create|edit>-letter-template(/<id>)
+                    regex_string = "^\\/templates(~[a-zA-Z0-9_\\-]{1,26})?\\/(create|edit)\\-letter\\-template(\\/[a-z0-9\\-]*)?$"
+                    text_transformation {
+                      priority = 10
+                      type     = "NONE"
+                    }
+                  }
                 }
-                # only uri to allow >8kb body is /templates(~<dynamic environment>)/<create|edit>-letter-template(/<id>)
-                regex_string = "^\\/templates(~[a-zA-Z0-9_\\-]{1,26})?\\/(create|edit)\\-letter\\-template(\\/[a-z0-9\\-]*)?$"
+              }
+            }
+            statement {
+              size_constraint_statement {
+                comparison_operator = "GT"
+                field_to_match {
+                  body {}
+                }
+                # 6MB lambda payload limit
+                size = 6291456
                 text_transformation {
                   priority = 10
-                  type = "NONE"
+                  type     = "NONE"
                 }
               }
             }
@@ -141,7 +159,7 @@ resource "aws_wafv2_web_acl" "main" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       sampled_requests_enabled   = true
-      metric_name                = "${local.csi}_geo_location_whitelist"
+      metric_name                = "${local.csi}_body_size_restriction"
     }
   }
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Set AWS standard body size waf rule to count, then deny if >6MB or not targeting pages where pdfs can be uploaded

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
